### PR TITLE
Remove sendgrid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'octokit'
 gem 'chronic'
 gem 'public_activity'
 gem 'vpim'
-gem 'sendgrid-ruby'
 # generate color schemes
 gem 'paleta'
 # security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,6 @@ GEM
       actionpack (>= 3.0.0)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mimemagic (0.3.1)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -449,10 +448,6 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sendgrid-ruby (1.1.6)
-      faraday (~> 0.9)
-      mimemagic
-      smtpapi (~> 0.1)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     simple_oauth (0.2.0)
@@ -463,7 +458,6 @@ GEM
     simplecov-html (0.8.0)
     site_meta (1.0.0)
       rails (>= 2.3.5)
-    smtpapi (0.1.0)
     spreadsheet (1.0.0)
       ruby-ole (>= 1.0)
     sprockets (3.7.1)
@@ -593,7 +587,6 @@ DEPENDENCIES
   secure_headers
   select2-rails
   selenium-webdriver
-  sendgrid-ruby
   shoulda-matchers
   simplecov
   site_meta
@@ -616,4 +609,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.3

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ActiveRecord::Base
   attr_accessor :login, :no_send_email, :skip_default_role, :unconfirmed_email
 
   before_create :add_to_organization
-  after_create :add_default_role, :send_new_email, :increment_stats
+  after_create :add_default_role, :increment_stats
   before_save :ensure_authentication_token
 
   # Setup accessible (or protected) attributes for your model
@@ -80,22 +80,6 @@ class User < ActiveRecord::Base
 
   def should_validate_organization_name?
     organization_id.nil?
-  end
-
-  def send_new_email
-    unless Rails.env.test? || (no_send_email == true)
-      $statsd.increment 'user.created'
-      client = SendGrid::Client.new(api_key: ENV['SENDGRID_PASSWORD'])
-      mail = SendGrid::Mail.new do |m|
-        m.to = 'contact@travisberry.com'
-        m.from = 'contact@hospitium.co'
-        m.subject = 'Hospitium New User'
-        m.text = "#{username} created an account. #{email} in organization #{organization.name}"
-      end
-      client.send(mail)
-    end
-  rescue => e
-    notify_airbrake(e)
   end
 
   def increment_stats

--- a/app/models/user_observer.rb
+++ b/app/models/user_observer.rb
@@ -2,13 +2,7 @@ require 'juggernaut'
 
 class UserObserver < ActiveRecord::Observer
   def after_update(user)
-    publish(:update, user) unless user.no_send_email == true
-  end
-
-  def before_save(user)
-    unless user.no_send_email == true
-      send_user_confirmed_email(user) if user.confirmed_at_changed?
-    end
+    publish(:update, user) unless user.no_send_email
   end
 
   def publish(_type, user)
@@ -21,21 +15,5 @@ class UserObserver < ActiveRecord::Observer
     # })
     ActionCable.server.broadcast "bip_#{user.id}",
                                  record: user.changes
-  end
-
-  def send_user_confirmed_email(user)
-    unless Rails.env.test?
-      $statsd.increment 'user.activated'
-      client = SendGrid::Client.new(api_key: ENV['SENDGRID_PASSWORD'])
-      mail = SendGrid::Mail.new do |m|
-        m.to = 'contact@travisberry.com'
-        m.from = 'contact@hospitium.co'
-        m.subject = 'Hospitium User Confirmed'
-        m.text = "#{user.username} confirmed an account. #{user.email} in organization #{user.organization_name}"
-      end
-      client.send(mail)
-    end
-  rescue => e
-    notify_airbrake(e)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,7 @@ AnimalTracker::Application.configure do
     authentication: :plain,
     user_name: ENV['SENDGRID_USERNAME'],
     password: ENV['SENDGRID_PASSWORD'],
-    domain: 'hospitium.co'
+    domain: ENV['SENDGRID_DOMAIN']
   }
   ActionMailer::Base.delivery_method = :smtp
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,8 +26,8 @@ AnimalTracker::Application.configure do
   # config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.default_url_options = { host: 'hospitium.co' }
   ActionMailer::Base.smtp_settings = {
-    address: 'smtp.sendgrid.net',
-    port: '587',
+    address: ENV.fetch('SMTP_SERVER', 'smtp.sendgrid.net'),
+    port: ENV.fetch('SMTP_PORT', '587'),
     authentication: :plain,
     user_name: ENV['SENDGRID_USERNAME'],
     password: ENV['SENDGRID_PASSWORD'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,7 +65,7 @@ AnimalTracker::Application.configure do
     authentication: :plain,
     user_name: ENV['SENDGRID_USERNAME'],
     password: ENV['SENDGRID_PASSWORD'],
-    domain: 'hospitium.co'
+    domain: ENV['SENDGRID_DOMAIN']
   }
   ActionMailer::Base.delivery_method = :smtp
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,8 +60,8 @@ AnimalTracker::Application.configure do
 
   config.action_mailer.default_url_options = { host: 'hospitium.co' }
   ActionMailer::Base.smtp_settings = {
-    address: 'smtp.sendgrid.net',
-    port: '587',
+    address: ENV.fetch('SMTP_SERVER', 'smtp.sendgrid.net'),
+    port: ENV.fetch('SMTP_PORT', '587'),
     authentication: :plain,
     user_name: ENV['SENDGRID_USERNAME'],
     password: ENV['SENDGRID_PASSWORD'],


### PR DESCRIPTION
This PR proposes two changes:

1. Remove email notifications to `contact@travisberry.com` on user actions (register, activate). 
2. Add SMTP server and port to `development` and `production` environment config with defaults of `smtp.sendgrid.net:587`.

The second change will allow us to set email preferences painlessly while maintaining backward-compatibility. 